### PR TITLE
Add basic queue

### DIFF
--- a/packages/notifications-backend-core/lib/notifications.js
+++ b/packages/notifications-backend-core/lib/notifications.js
@@ -84,11 +84,22 @@ module.exports = function buildNotificationService(db, config = {}) {
       notifmeSdkConfig.channels[channel].providers.push(Object.assign({}, { type: name }, handler))
     }
 
-    async send(notification, strategy = 'default') {
+    async send(notification, strategy) {
+      if (!strategy) {
+        strategy = 'default'
+      }
+
       if (!config.strategies || !config.strategies[strategy]) {
         return {
           status: 'error',
           message: `Cannot send notification with a non existing strategy (${strategy})`
+        }
+      }
+
+      if (!config.strategies[strategy].channels) {
+        return {
+          status: 'error',
+          message: `No channel specified for strategy (${strategy})`
         }
       }
 

--- a/packages/notifications-backend-hapi-plugin/lib/subscriptions.js
+++ b/packages/notifications-backend-hapi-plugin/lib/subscriptions.js
@@ -11,10 +11,14 @@ async function notifyUser(notification) {
 
   let isUserSubscribed = false
   server.eachSocket(
-    () => {
-      isUserSubscribed = true
-    },
-    { subscription: `/users/${notification.userIdentifier}` }
+    socket => {
+      if (!isUserSubscribed) {
+        isUserSubscribed = !!socket._subscriptions[`/users/${notification.userIdentifier}`]
+      }
+    }
+    // @see https://github.com/hapijs/nes/issues/248
+    // ,
+    // { subscription: `/users/${notification.userIdentifier}` }
   )
 
   if (!isUserSubscribed) {

--- a/packages/notifications-backend-hapi-plugin/lib/test-queue.js
+++ b/packages/notifications-backend-hapi-plugin/lib/test-queue.js
@@ -1,0 +1,28 @@
+'use strict'
+
+class TestQueue {
+  constructor() {
+    this.queues = []
+  }
+
+  async sendToQueue(queue, message) {
+    if (!this.queues || !this.queues[queue]) {
+      return null
+    }
+
+    const tasks = this.queues[queue].map(handler => handler(message))
+    const result = await Promise.all(tasks)
+
+    return result
+  }
+
+  consume(queue, handler) {
+    if (!this.queues[queue]) {
+      this.queues[queue] = []
+    }
+
+    this.queues[queue].push(handler)
+  }
+}
+
+module.exports = { TestQueue }

--- a/packages/notifications-backend-hapi-plugin/test/server-notification-sent.test.js
+++ b/packages/notifications-backend-hapi-plugin/test/server-notification-sent.test.js
@@ -1,0 +1,62 @@
+'use strict'
+
+const { expect } = require('code')
+const Lab = require('lab')
+
+module.exports.lab = Lab.script()
+const { describe, it: test, before, beforeEach, after } = module.exports.lab
+
+const { resetDb, loadDataFromTable } = require('../../notifications-backend-core/test/utils')
+const buildServer = require('./test-server')
+
+describe('Notifications REST API', () => {
+  let server = null
+
+  before(async () => {
+    server = await buildServer({
+      host: '127.0.0.1',
+      port: 8281,
+      pluginOptions: { nes: {} }
+    })
+  })
+
+  beforeEach(async () => {
+    await resetDb()
+  })
+
+  after(async () => {
+    return server.stop()
+  })
+
+  describe('POST /notifications', () => {
+    test('it should create a notification', async () => {
+      const response = await server.inject({
+        method: 'POST',
+        url: '/notifications',
+        payload: {
+          notify: { username: 'davide', message: 'some message here' },
+          userIdentifier: 'davide'
+        }
+      })
+
+      expect(response.statusCode).to.equal(200)
+      const result = JSON.parse(response.payload)
+
+      expect(result).to.include({
+        notify: { username: 'davide', message: 'some message here' },
+        readAt: null,
+        deletedAt: null,
+        sendStrategy: null,
+        sentBy: [],
+        userIdentifier: 'davide'
+      })
+
+      const sentByRecords = await loadDataFromTable('sent_by')
+      expect(sentByRecords.length).to.equal(1)
+      expect(sentByRecords[0]).to.include({
+        notification_id: 1,
+        channel: 'test'
+      })
+    })
+  })
+})

--- a/packages/notifications-backend-hapi-plugin/test/test-queue.test.js
+++ b/packages/notifications-backend-hapi-plugin/test/test-queue.test.js
@@ -1,0 +1,33 @@
+'use strict'
+
+const { expect } = require('code')
+const Lab = require('lab')
+module.exports.lab = Lab.script()
+const { describe, it: test } = module.exports.lab
+
+const { TestQueue } = require('../lib/test-queue')
+
+describe('Test queue', () => {
+  test('sendToQueue: it should return null if no queue has been registered', async () => {
+    const queue = new TestQueue()
+    const result = await queue.sendToQueue('random', {})
+
+    expect(result).to.be.null()
+  })
+
+  test('sendToQueue: it should return null if publishing on a different queue that the present ones', async () => {
+    const queue = new TestQueue()
+    queue.consume('my-queue', async () => ({ result: ' success' }))
+
+    const result = await queue.sendToQueue('random', {})
+    expect(result).to.be.null()
+  })
+
+  test('sendToQueue: it should return the list of result for each handler', async () => {
+    const queue = new TestQueue()
+    queue.consume('my-queue', async () => ({ result: ' success' }))
+
+    const result = await queue.sendToQueue('my-queue', {})
+    expect(result).to.equal([{ result: ' success' }])
+  })
+})

--- a/packages/notifications-backend-hapi-plugin/test/test-server.js
+++ b/packages/notifications-backend-hapi-plugin/test/test-server.js
@@ -45,7 +45,9 @@ module.exports = async function buildServer(config = {}, options = {}) {
     if (!config.pluginOptions) {
       config.pluginOptions = {
         strategies: {
-          default: {}
+          default: {
+            channels: ['websocket']
+          }
         }
       }
     }

--- a/packages/notifications-server/config/index.js
+++ b/packages/notifications-server/config/index.js
@@ -3,11 +3,11 @@
 const { NF_NOTIFICATIONS_SERVER_HOST, NF_NOTIFICATIONS_SERVER_PORT } = process.env
 
 const config = {
+  pluginOptions: { nes: {} },
   server: {
     host: NF_NOTIFICATIONS_SERVER_HOST || 'localhost',
-    port: NF_NOTIFICATIONS_SERVER_PORT || 8080
-  },
-  pluginOptions: { nes: {} }
+    port: NF_NOTIFICATIONS_SERVER_PORT || 8482
+  }
 }
 
 module.exports = config

--- a/packages/notifications-server/src/default-config-builder.js
+++ b/packages/notifications-server/src/default-config-builder.js
@@ -6,9 +6,8 @@ async function defaultConfigBuilder(server) {
       socket: {
         mysocketservice: async notification => {
           const result = await server.notifyViaWebsocket(notification)
-          if (result.success === true) {
-            server.notificationsService.sentBy({ id: notification.id, channel: 'socket' })
-          }
+
+          return result
         }
       }
     },

--- a/packages/notifications-server/src/server.js
+++ b/packages/notifications-server/src/server.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const Hapi = require('hapi')
-const { defaultConfigBuilder } = require('../default-config-builder')
+const { defaultConfigBuilder } = require('./default-config-builder')
 
 function registerChannelsAndProviders(notifications, config) {
   if (!config.channels) throw new Error('No channels provided in config')
@@ -16,7 +16,8 @@ function registerChannelsAndProviders(notifications, config) {
 
 async function buildServer(defaultConfig) {
   const server = Hapi.server(defaultConfig.server)
-  server.register({
+
+  await server.register({
     plugin: require('../../notifications-backend-hapi-plugin/lib/index'),
     options: defaultConfig.pluginOptions
   })


### PR DESCRIPTION
This PR adds a very basic implementation of a "queue" module and it's integration in the plugin package.

It works like this:

- plugin is initialized
- a "queue" producer is added: it will queue a notification on the `notificationsService` `add` event
- a "queue" consumer is added: it will call `notificationsService.send`

The queue object works that as soon as someone send a new message to the queue, it will broadcast it to all it's consumers.
