### PR TITLE
Introduce hapi 16 version of plugins

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "sanity:environment": "npm run doc:lint && npm run lint && npm run depcheck",
     "sanity": "npm run sanity:environment && npm run test",
     "start": "cd packages/notificami-server && npm run start",
-    "test": "lerna run test"
+    "test": "lerna run test --concurrency 1 --stream"
   },
   "contributors": [
     "Filippo De Santis (https://github.com/p16)",

--- a/packages/notificami-backend-core/lib/notifications.js
+++ b/packages/notificami-backend-core/lib/notifications.js
@@ -93,9 +93,7 @@ module.exports = function buildNotificationService(storage, config = {}) {
 
     async add({ notify, sendStrategy, userIdentifier }) {
       let notification = await storage.add({ notify, sendStrategy, userIdentifier })
-
       this.emit('add', notification)
-
       return notification
     }
 

--- a/packages/notificami-backend-core/test/utils.js
+++ b/packages/notificami-backend-core/test/utils.js
@@ -20,7 +20,7 @@ async function resetDb() {
 
     await checkDatabaseExists(pool, config.pg.database)
     await resetTables(pool)
-    await pool.end()
+    // await pool.end()
     await runMigrations(config.pg)
   } catch (e) {
     console.error(e) // eslint-disable-line no-console
@@ -32,7 +32,7 @@ async function loadDataFromTable(table) {
   const pool = buildPool(config.pg)
 
   const result = await pool.query(`SELECT * FROM ${table}`)
-  await pool.end()
+  // await pool.end()
 
   return result.rows
 }

--- a/packages/notificami-backend-hapi-16-plugin/LICENSE.md
+++ b/packages/notificami-backend-hapi-16-plugin/LICENSE.md
@@ -1,0 +1,13 @@
+Copyright (c) 2018 nearForm
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/packages/notificami-backend-hapi-16-plugin/README.md
+++ b/packages/notificami-backend-hapi-16-plugin/README.md
@@ -1,0 +1,126 @@
+# @nearform/notificami-backend-hapi-plugin
+
+`@nearform/notificami-backend-hapi-plugin` is a plugin to add the notificami REST API and Websockets to a [Hapi (17+)][hapi] server. It relies on the [`@nearform/notificami-backend-core` module](https://github.com/nearform/notificami/tree/master/packages/notificami-backend-core).
+
+## Install
+
+To install via npm:
+
+```
+npm install @nearform/notificami-backend-hapi-plugin
+```
+
+## Configuration
+
+When initializing the `@nearform/notificami-backend-hapi-plugin`, it will accept a options object of the followig format
+
+```
+{
+  plugins: [{ plugin: '@nearform/notificami-backend-local-queue' }],
+  storage: {
+    plugin: '@nearform/notificami-storage-dynamodb',
+    options: {
+     TableName: 'notifications',
+     ApplicationUserAccessKey: 'AKIAJVUSIUSERACCESSKEY',
+     ApplicationUserSecretAccessKey: 'c9AHgAjhpsercretuseraccesskey',
+     Region: 'eu-west-1'
+   }
+  },
+  channels: {
+    email: {
+      ses: {
+        region: 'xxxxx',
+        accessKeyId: 'xxxxx',
+        secretAccessKey: 'xxxxx'
+      },
+      sendgrid: async (notification) => {}
+    },
+    socket: {
+      plugin: '@nearform/notificami-channel-websocket-nes'
+    }
+  },
+  strategies: {
+    default: {
+      name: 'default-to-sockets',
+      channels: ['socket', 'email']
+    }
+  }
+}
+```
+
+The `plugins` option should contain an array of plugins to be used. We will install each plugin as an hapi plugin. An example on how to use and configure a plugin can be found in the [@nearform/notificami-sqs-queue](https://github.com/nearform/notificami/tree/master/packages/notificami-sqs-queue) module.
+
+The `storage` option should contain an obect with definition of the storage used. If no storage is defined the default `postgres` storage is used. An example on how to use and configure the storage can be found in the [@nearform/notificami-storage-dynamodb](https://github.com/nearform/notificami/tree/master/packages/notificami-storage-dynamodb) module.
+
+The `channels` option should be an object declaring which are the channels to be registered on `notif.me sdk`, they can be either an object (as `email.ses`) or an async function (as `email.sendgrid`) or a module to be required (as `socket`) that [will add its own channels/providers](#@nearform/notificami-channel-websocket-nes).
+
+To have a list of already implemented provider you can refer to [the providers list from `notif.me sdk`](https://github.com/notifme/notifme-sdk#2-providers)
+
+The `strategies` option may define different strategies to use when delivering notifications. Each strategy should contain a list of channels. If the strategy in the [notification request](#@nearform/notificami-backend-hapi-plugin) matches one of the strategies we definend, its channels will be used to send the notification. We will loop on the channels and stop at the first one that its successful in sending the notification.
+
+
+## <a name="api"></a> HTTP APIs
+The plugin mounts the following endpoints
+
+**GET /users/{username}/notifications/{offsetId?}**
+
+This endpoint will return the list of notifications for a user from the newest to the oldest starting from the notification with ID=`offestId`. If `offsetId`is not defined, the newest notifications are returned.
+
+Return structure:
+```
+{
+  items: [...],
+  hasMore: true|false
+}
+```
+
+**POST /notifications**
+
+This endpoint will create a new notification and trigger the notification process through a strategy.
+
+The request should be something like the followig:
+
+```
+
+POST /notifications
+
+{
+  notify: { /* free structure */ },
+  userIdentifier: 'xyz',
+  sendStrategy: 'default' // this is optional
+}
+```
+
+and the response will be (if using our postgres storage implementation)
+
+```
+{
+  notify: { /* what has been passed in */ },
+  readAt: null,
+  deletedAt: null,
+  sendStrategy: 'default',
+  sentBy: [],
+  userIdentifier: 'xyz'
+}
+```
+
+**PUT /notifications/{idNotification}/read**
+
+Set the notification `idNotification` as read
+
+**PUT /notifications/{idNotification}/unread**
+
+Set the notification `idNotification` as unread
+
+
+**DELETE /notifications/{id}**
+
+This endpoint will delete a notification.
+
+
+## License
+
+Copyright nearForm Ltd 2018. Licensed under [Apache 2.0 license][license].
+
+[hapi]: https://hapijs.com/
+[license]: ./LICENSE.md

--- a/packages/notificami-backend-hapi-16-plugin/README.md
+++ b/packages/notificami-backend-hapi-16-plugin/README.md
@@ -1,18 +1,18 @@
-# @nearform/notificami-backend-hapi-plugin
+# @nearform/notificami-backend-hapi-16-plugin
 
-`@nearform/notificami-backend-hapi-plugin` is a plugin to add the notificami REST API and Websockets to a [Hapi (17+)][hapi] server. It relies on the [`@nearform/notificami-backend-core` module](https://github.com/nearform/notificami/tree/master/packages/notificami-backend-core).
+`@nearform/notificami-backend-hapi-16-plugin` is a plugin to add the notificami REST API and Websockets to a [Hapi (16)][hapi] server. It relies on the [`@nearform/notificami-backend-core` module](https://github.com/nearform/notificami/tree/master/packages/notificami-backend-core).
 
 ## Install
 
 To install via npm:
 
 ```
-npm install @nearform/notificami-backend-hapi-plugin
+npm install @nearform/notificami-backend-hapi-16-plugin
 ```
 
 ## Configuration
 
-When initializing the `@nearform/notificami-backend-hapi-plugin`, it will accept a options object of the followig format
+When initializing the `@nearform/notificami-backend-hapi-16-plugin`, it will accept a options object of the followig format
 
 ```
 {
@@ -36,7 +36,7 @@ When initializing the `@nearform/notificami-backend-hapi-plugin`, it will accept
       sendgrid: async (notification) => {}
     },
     socket: {
-      plugin: '@nearform/notificami-channel-websocket-nes'
+      plugin: '@nearform/notificami-channel-websocket-nes-6-hapi-16'
     }
   },
   strategies: {
@@ -56,7 +56,7 @@ The `channels` option should be an object declaring which are the channels to be
 
 To have a list of already implemented provider you can refer to [the providers list from `notif.me sdk`](https://github.com/notifme/notifme-sdk#2-providers)
 
-The `strategies` option may define different strategies to use when delivering notifications. Each strategy should contain a list of channels. If the strategy in the [notification request](#@nearform/notificami-backend-hapi-plugin) matches one of the strategies we definend, its channels will be used to send the notification. We will loop on the channels and stop at the first one that its successful in sending the notification.
+The `strategies` option may define different strategies to use when delivering notifications. Each strategy should contain a list of channels. If the strategy in the [notification request](#@nearform/notificami-backend-hapi-16-plugin) matches one of the strategies we definend, its channels will be used to send the notification. We will loop on the channels and stop at the first one that its successful in sending the notification.
 
 
 ## <a name="api"></a> HTTP APIs

--- a/packages/notificami-backend-hapi-16-plugin/lib/index.js
+++ b/packages/notificami-backend-hapi-16-plugin/lib/index.js
@@ -1,0 +1,82 @@
+'use strict'
+
+const Joi = require('joi')
+const { name, version } = require('../package.json')
+const { buildNotificationsService, buildPool, config, PostgresStorage } = require('@nearform/notificami-backend-core')
+
+const schema = Joi.object({
+  pg: Joi.object().optional(),
+  strategies: Joi.object().optional()
+})
+
+const notificationsHapiPlugin = {
+  name,
+  version,
+  register: async function(server, options = {}) {
+    const result = Joi.validate(options, schema, { allowUnknown: true })
+    if (result.error) {
+      throw result.error
+    }
+
+    if (options.storage && options.storage.plugin) {
+      try {
+        await server.register({ plugin: require(options.storage.plugin), options: options.storage.options || {} })
+      } catch (e) {
+        server.log(['error', 'initialize-storage', options.storage.plugin], e)
+      }
+    }
+
+    let db = options.db
+    if (!db) {
+      db = buildPool(Object.assign({}, config.pg, options.pg))
+    }
+
+    const notificationsService = buildNotificationsService(
+      server.storageService ? server.storageService : new PostgresStorage(db),
+      { strategies: options.strategies }
+    )
+
+    server.decorate('server', 'notificationsService', notificationsService)
+    server.decorate('request', 'notificationsService', notificationsService)
+
+    if (options.channels) {
+      const channels = Object.keys(options.channels)
+      for (let index = 0; index < channels.length; index++) {
+        const value = options.channels[channels[index]]
+
+        if (value.plugin) {
+          try {
+            await server.register({ plugin: require(value.plugin), options: value.options || {} })
+          } catch (e) {
+            server.log(['error', 'initialize-channel', value.plugin], e)
+          }
+        } else {
+          const channel = channels[index]
+          const providerNames = Object.keys(value)
+          for (let index = 0; index < providerNames.length; index++) {
+            await server.notificationsService.register(channel, providerNames[index], value[providerNames[index]])
+          }
+        }
+      }
+    }
+
+    if (options.plugins) {
+      for (let index = 0; index < options.plugins.length; index++) {
+        const value = options.plugins[index]
+        try {
+          await server.register({ plugin: require(value.plugin), options: value.options || {} })
+        } catch (e) {
+          server.log(['error', 'initialize-plugin', value.plugin], e)
+        }
+      }
+    }
+
+    await server.register([{ plugin: require('./routes'), options: options.routes }])
+
+    server.ext('onPostStop', async () => {
+      await notificationsService.close()
+    })
+  }
+}
+
+module.exports = notificationsHapiPlugin

--- a/packages/notificami-backend-hapi-16-plugin/lib/routes.js
+++ b/packages/notificami-backend-hapi-16-plugin/lib/routes.js
@@ -1,0 +1,116 @@
+'use strict'
+
+const Joi = require('joi')
+
+module.exports = {
+  name: 'notifications',
+  register(server, options = {}) {
+    const { cors = false, auth = false } = options
+
+    server.route({
+      method: 'GET',
+      path: '/users/{username}/notifications/{offsetId?}',
+      handler: async function(request, h) {
+        const { username, offsetId } = request.params
+        const results = await request.notificationsService.getByUserIdentifier(username, offsetId)
+        if (results.hasMore === undefined) {
+          results.hasMore = false
+          if (results.items.length > 0) {
+            results.hasMore = await request.notificationsService.hasMoreByUserIdentifier(
+              username,
+              results.items[results.items.length - 1].id
+            )
+          }
+        }
+        return { items: results.items, hasMore: results.hasMore }
+      },
+      options: {
+        cors,
+        auth,
+        validate: {
+          params: {
+            username: Joi.string().required(),
+            offsetId: Joi.string()
+          }
+        }
+      }
+    })
+
+    server.route({
+      method: 'POST',
+      path: '/notifications',
+      handler: async function(request, h) {
+        return request.notificationsService.add(request.payload)
+      },
+      options: {
+        cors,
+        auth,
+        validate: {
+          payload: {
+            notify: Joi.object().required(),
+            sendStrategy: Joi.string(),
+            userIdentifier: Joi.string().required()
+          }
+        }
+      }
+    })
+
+    server.route({
+      method: 'PUT',
+      path: '/notifications/{id}/read',
+      handler: async function(request, h) {
+        const { id } = request.params
+
+        return request.notificationsService.setRead({ id })
+      },
+      options: {
+        cors,
+        auth,
+        validate: {
+          params: {
+            id: Joi.number().required()
+          }
+        }
+      }
+    })
+
+    server.route({
+      method: 'PUT',
+      path: '/notifications/{id}/unread',
+      handler: async function(request, h) {
+        const { id } = request.params
+
+        return request.notificationsService.setUnread({ id })
+      },
+      options: {
+        cors,
+        auth,
+        validate: {
+          params: {
+            id: Joi.number().required()
+          }
+        }
+      }
+    })
+
+    server.route({
+      method: 'DELETE',
+      path: '/notifications/{id}',
+      handler: async function(request, h) {
+        const { id } = request.params
+
+        await request.notificationsService.delete({ id })
+        return { success: true }
+      },
+      options: {
+        cors,
+        auth,
+        validate: {
+          params: {
+            id: Joi.number().required()
+          }
+        }
+      }
+    })
+  }
+}

--- a/packages/notificami-backend-hapi-16-plugin/package.json
+++ b/packages/notificami-backend-hapi-16-plugin/package.json
@@ -1,8 +1,8 @@
 {
-  "name": "@nearform/notificami-backend-hapi-plugin",
+  "name": "@nearform/notificami-backend-hapi-16-plugin",
   "version": "0.0.1",
   "main": "lib/index.js",
-  "description": "notificami-backend-hapi-plugin",
+  "description": "notificami-backend-hapi-16-plugin",
   "homepage": "https://github.com/nearform/notificami#readme",
   "repository": {
     "type": "git",
@@ -17,28 +17,29 @@
   "scripts": {
     "coverage": "NODE_ENV=test lab -c -r lcov test",
     "pg:test:init": "NODE_ENV=test node ../notificami-backend-core/database/init.js && NODE_ENV=test node ../notificami-backend-core/database/migrate.js max",
-    "depcheck": "../../node_modules/depcheck/bin/depcheck --ignores=@nearform/notificami-channel-websocket-nes,@nearform/notificami-backend-local-queue,@nearform/notificami-backend-sqs-queue,@nearform/notificami-storage-dynamodb",
+    "depcheck": "../../node_modules/depcheck/bin/depcheck --ignores=@nearform/notificami-channel-websocket-nes,@nearform/notificami-channel-websocket-nes-6-hapi-16,@nearform/notificami-backend-local-queue,@nearform/notificami-backend-sqs-queue,@nearform/notificami-storage-dynamodb",
     "test": "NODE_ENV=test lab -c test -I __core-js_shared__"
   },
   "contributors": [
     "Filippo De Santis (https://github.com/p16)",
-    "Davide Fiorello (https://github.com/codeflyer)"
+    "Davide Fiorello (https://github.com/codeflyer)",
+    "Florian Traverse (https://github.com/temsa)"
   ],
   "author": "nearForm Ltd",
   "license": "Apache-2.0",
   "dependencies": {
-    "joi": "^13.4.0",
-    "nes": "^9.0.0",
     "@nearform/notificami-backend-core": "^0.0.1",
     "@nearform/notificami-backend-sqs-queue": "^0.0.1",
-    "@nearform/notificami-storage-dynamodb": "^0.0.1"
+    "@nearform/notificami-storage-dynamodb": "^0.0.1",
+    "joi": "^13.4.0"
   },
   "devDependencies": {
-    "code": "^5.2.0",
-    "hapi": "^17.5.2",
-    "lab": "^15.4.5",
     "@nearform/notificami-backend-local-queue": "^0.0.1",
-    "@nearform/notificami-channel-websocket-nes": "^0.0.1",
+    "@nearform/notificami-channel-websocket-nes-6-hapi-16": "^0.0.1",
+    "code": "^5.2.0",
+    "hapi": "^16.6.3",
+    "lab": "^15.4.5",
+    "nes": "^6.5.2",
     "sinon": "^6.0.1"
   }
 }

--- a/packages/notificami-backend-hapi-16-plugin/package.json
+++ b/packages/notificami-backend-hapi-16-plugin/package.json
@@ -1,0 +1,44 @@
+{
+  "name": "@nearform/notificami-backend-hapi-plugin",
+  "version": "0.0.1",
+  "main": "lib/index.js",
+  "description": "notificami-backend-hapi-plugin",
+  "homepage": "https://github.com/nearform/notificami#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/nearform/notificami.git"
+  },
+  "bugs": {
+    "url": "https://github.com/nearform/notificami/issues"
+  },
+  "engines": {
+    "node": ">=8.9.0"
+  },
+  "scripts": {
+    "coverage": "NODE_ENV=test lab -c -r lcov test",
+    "pg:test:init": "NODE_ENV=test node ../notificami-backend-core/database/init.js && NODE_ENV=test node ../notificami-backend-core/database/migrate.js max",
+    "depcheck": "../../node_modules/depcheck/bin/depcheck --ignores=@nearform/notificami-channel-websocket-nes,@nearform/notificami-backend-local-queue,@nearform/notificami-backend-sqs-queue,@nearform/notificami-storage-dynamodb",
+    "test": "NODE_ENV=test lab -c test -I __core-js_shared__"
+  },
+  "contributors": [
+    "Filippo De Santis (https://github.com/p16)",
+    "Davide Fiorello (https://github.com/codeflyer)"
+  ],
+  "author": "nearForm Ltd",
+  "license": "Apache-2.0",
+  "dependencies": {
+    "joi": "^13.4.0",
+    "nes": "^9.0.0",
+    "@nearform/notificami-backend-core": "^0.0.1",
+    "@nearform/notificami-backend-sqs-queue": "^0.0.1",
+    "@nearform/notificami-storage-dynamodb": "^0.0.1"
+  },
+  "devDependencies": {
+    "code": "^5.2.0",
+    "hapi": "^17.5.2",
+    "lab": "^15.4.5",
+    "@nearform/notificami-backend-local-queue": "^0.0.1",
+    "@nearform/notificami-channel-websocket-nes": "^0.0.1",
+    "sinon": "^6.0.1"
+  }
+}

--- a/packages/notificami-backend-hapi-16-plugin/test/__mockData__/notifications.js
+++ b/packages/notificami-backend-hapi-16-plugin/test/__mockData__/notifications.js
@@ -1,0 +1,68 @@
+module.exports = [
+  {
+    notify: { user: 'davide', content: 'Some notification content 1' },
+    sendStrategy: 'default',
+    userIdentifier: 'davide',
+    createdAt: new Date('05 May 2018 14:48 UTC').toISOString()
+  },
+  {
+    notify: { user: 'davide', content: 'Some notification content 2' },
+    sendStrategy: 'default',
+    userIdentifier: 'davide',
+    createdAt: new Date('06 May 2018 14:48 UTC').toISOString()
+  },
+  {
+    notify: { user: 'davide', content: 'Some notification content 3' },
+    sendStrategy: 'default',
+    userIdentifier: 'davide',
+    createdAt: new Date('07 May 2018 14:48 UTC').toISOString()
+  },
+  {
+    notify: { user: 'davide', content: 'Some notification content 4' },
+    sendStrategy: 'default',
+    userIdentifier: 'davide',
+    createdAt: new Date('08 May 2018 14:48 UTC').toISOString()
+  },
+  {
+    notify: { user: 'davide', content: 'Some notification content 5' },
+    sendStrategy: 'default',
+    userIdentifier: 'davide',
+    createdAt: new Date('09 May 2018 14:48 UTC').toISOString()
+  },
+  {
+    notify: { user: 'davide', content: 'Some notification content 6' },
+    sendStrategy: 'default',
+    userIdentifier: 'davide',
+    createdAt: new Date('10 May 2018 14:48 UTC').toISOString()
+  },
+  {
+    notify: { user: 'filippo', content: 'Some notification to Filippo 1' },
+    sendStrategy: 'default',
+    userIdentifier: 'filippo',
+    createdAt: new Date('10 May 2018 16:48 UTC').toISOString()
+  },
+  {
+    notify: { user: 'davide', content: 'Some notification content 7' },
+    sendStrategy: 'default',
+    userIdentifier: 'davide',
+    createdAt: new Date('11 May 2018 14:48 UTC').toISOString()
+  },
+  {
+    notify: { user: 'davide', content: 'Some notification content 8' },
+    sendStrategy: 'default',
+    userIdentifier: 'davide',
+    createdAt: new Date('12 May 2018 14:48 UTC').toISOString()
+  },
+  {
+    notify: { user: 'davide', content: 'Some notification content 9' },
+    sendStrategy: 'default',
+    userIdentifier: 'davide',
+    createdAt: new Date('13 May 2018 14:48 UTC').toISOString()
+  },
+  {
+    notify: { user: 'filippo', content: 'Some notification to Filippo 2' },
+    sendStrategy: 'default',
+    userIdentifier: 'filippo',
+    createdAt: new Date('13 May 2018 16:48 UTC').toISOString()
+  }
+]

--- a/packages/notificami-backend-hapi-16-plugin/test/server-notification-sent.test.js
+++ b/packages/notificami-backend-hapi-16-plugin/test/server-notification-sent.test.js
@@ -1,0 +1,82 @@
+'use strict'
+
+const { expect } = require('code')
+const Lab = require('lab')
+
+module.exports.lab = Lab.script()
+const { describe, it: test, before, beforeEach, after } = module.exports.lab
+
+const { resetDb, loadDataFromTable } = require('@nearform/notificami-backend-core/test/utils')
+const buildServer = require('./test-server')
+
+describe('Notifications REST API', () => {
+  let server = null
+
+  before(async () => {
+    server = await buildServer({
+      host: '127.0.0.1',
+      port: 8281,
+      pluginOptions: {
+        plugins: [{ plugin: '@nearform/notificami-backend-local-queue' }],
+        channels: {
+          email: {
+            ses: {
+              region: 'xxxxx',
+              accessKeyId: 'xxxxx',
+              secretAccessKey: 'xxxxx'
+            },
+            sendgrid: {
+              apiKey: 'xxxxx'
+            }
+          }
+        },
+        strategies: {
+          default: {
+            name: 'default-to-sockets',
+            channels: ['test']
+          }
+        }
+      }
+    })
+  })
+
+  beforeEach(async () => {
+    await resetDb()
+  })
+
+  after(async () => {
+    return server.stop()
+  })
+
+  describe('POST /notifications', () => {
+    test('it should create a notification', async () => {
+      const response = await server.inject({
+        method: 'POST',
+        url: '/notifications',
+        payload: {
+          notify: { username: 'davide', message: 'some message here' },
+          userIdentifier: 'davide'
+        }
+      })
+
+      expect(response.statusCode).to.equal(200)
+      const result = JSON.parse(response.payload)
+
+      expect(result).to.include({
+        notify: { username: 'davide', message: 'some message here' },
+        readAt: null,
+        deletedAt: null,
+        sendStrategy: null,
+        sentBy: [],
+        userIdentifier: 'davide'
+      })
+
+      const sentByRecords = await loadDataFromTable('sent_by')
+      expect(sentByRecords.length).to.equal(1)
+      expect(sentByRecords[0]).to.include({
+        notification_id: 1,
+        channel: 'test'
+      })
+    })
+  })
+})

--- a/packages/notificami-backend-hapi-16-plugin/test/server-notification-sent.test.js
+++ b/packages/notificami-backend-hapi-16-plugin/test/server-notification-sent.test.js
@@ -10,7 +10,7 @@ const { resetDb, loadDataFromTable } = require('@nearform/notificami-backend-cor
 const buildServer = require('./test-server')
 
 describe('Notifications REST API', () => {
-  let server = null
+  let server
 
   before(async () => {
     server = await buildServer({
@@ -38,14 +38,15 @@ describe('Notifications REST API', () => {
         }
       }
     })
+    await server.start()
   })
 
   beforeEach(async () => {
     await resetDb()
   })
 
-  after(async () => {
-    return server.stop()
+  after(() => {
+    server.stop()
   })
 
   describe('POST /notifications', () => {

--- a/packages/notificami-backend-hapi-16-plugin/test/server-register.test.js
+++ b/packages/notificami-backend-hapi-16-plugin/test/server-register.test.js
@@ -1,0 +1,56 @@
+'use strict'
+
+const { expect, fail } = require('code')
+const Lab = require('lab')
+const sinon = require('sinon')
+
+module.exports.lab = Lab.script()
+const { describe, it: test, beforeEach, afterEach } = module.exports.lab
+
+const logMessage = process.send ? process.send : console.log // eslint-disable-line no-console
+describe('Notifications REST API Registration', () => {
+  let loggerStub
+  let server = null
+
+  beforeEach(async () => {
+    try {
+      loggerStub = sinon.spy()
+      server = require('hapi').Server({
+        host: '127.0.0.1',
+        port: 8080
+      })
+      server.events.on('log', loggerStub)
+    } catch (err) {
+      logMessage(`Failed to build server: ${err.message}`)
+      process.exit(1)
+    }
+  })
+
+  afterEach(async () => {
+    return server.stop()
+  })
+
+  test('validate the parameters', async () => {
+    try {
+      await server.register({
+        plugin: require('../lib/index'),
+        options: { pg: 'somevalue' }
+      })
+      fail('I should have chatched an error...')
+    } catch (e) {
+      expect(e.message).equal('child "pg" fails because ["pg" must be an object]')
+    }
+  })
+
+  test('if the storage contains a value should be used', async () => {
+    await server.register({
+      plugin: require('../lib/index'),
+      options: {
+        storage: {
+          plugin: 'someplugin'
+        }
+      }
+    })
+    expect(loggerStub.getCall(0).args[0].tags).to.be.equal(['error', 'initialize-storage', 'someplugin'])
+  })
+})

--- a/packages/notificami-backend-hapi-16-plugin/test/server.test.js
+++ b/packages/notificami-backend-hapi-16-plugin/test/server.test.js
@@ -1,0 +1,175 @@
+'use strict'
+
+const { expect } = require('code')
+const Lab = require('lab')
+
+module.exports.lab = Lab.script()
+const { describe, it: test, before, beforeEach, after } = module.exports.lab
+
+const { resetDb } = require('@nearform/notificami-backend-core/test/utils')
+const buildServer = require('./test-server')
+const notificationsMockData = require('./__mockData__/notifications')
+
+describe('Notifications REST API', () => {
+  let server = null
+
+  before(async () => {
+    server = await buildServer()
+  })
+
+  beforeEach(async () => {
+    await resetDb()
+  })
+
+  after(async () => {
+    return server.stop()
+  })
+
+  describe('GET /users/{userIdentifier}/notifications', () => {
+    beforeEach(async () => {
+      for (let { notify, sendStrategy, userIdentifier } of notificationsMockData) {
+        await server.notificationsService.add({
+          notify,
+          sendStrategy,
+          userIdentifier
+        })
+      }
+    })
+
+    test('it should get the list related to the user from the top', async () => {
+      const response = await server.inject({
+        method: 'GET',
+        url: `/users/davide/notifications`
+      })
+
+      expect(response.statusCode).to.equal(200)
+      const { items, hasMore } = JSON.parse(response.payload)
+
+      expect(items.length).to.be.equal(5)
+      expect(items[0].notify.content).to.be.equal('Some notification content 9')
+      expect(items[1].notify.content).to.be.equal('Some notification content 8')
+      expect(items[2].notify.content).to.be.equal('Some notification content 7')
+      expect(items[3].notify.content).to.be.equal('Some notification content 6')
+      expect(items[4].notify.content).to.be.equal('Some notification content 5')
+      expect(hasMore).to.be.true()
+    })
+
+    test('it should get the list related to the user from a specific ID', async () => {
+      const response = await server.inject({
+        method: 'GET',
+        url: `/users/davide/notifications/5`
+      })
+
+      expect(response.statusCode).to.equal(200)
+      const { items, hasMore } = JSON.parse(response.payload)
+
+      expect(items.length).to.be.equal(4)
+      expect(items[0].notify.content).to.be.equal('Some notification content 4')
+      expect(items[1].notify.content).to.be.equal('Some notification content 3')
+      expect(items[2].notify.content).to.be.equal('Some notification content 2')
+      expect(items[3].notify.content).to.be.equal('Some notification content 1')
+      expect(hasMore).to.be.false()
+    })
+
+    test('it should get the list related to the user from a specific ID without any results', async () => {
+      const response = await server.inject({
+        method: 'GET',
+        url: `/users/filippo/notifications/5`
+      })
+
+      expect(response.statusCode).to.equal(200)
+      const { items, hasMore } = JSON.parse(response.payload)
+
+      expect(items.length).to.be.equal(0)
+      expect(hasMore).to.be.false()
+    })
+  })
+
+  describe('POST /notifications', () => {
+    test('it should create a notification', async () => {
+      const response = await server.inject({
+        method: 'POST',
+        url: '/notifications',
+        payload: {
+          notify: { username: 'davide', message: 'some message here' },
+          userIdentifier: 'davide'
+        }
+      })
+
+      expect(response.statusCode).to.equal(200)
+      const result = JSON.parse(response.payload)
+
+      expect(result).to.include({
+        notify: { username: 'davide', message: 'some message here' },
+        readAt: null,
+        deletedAt: null,
+        sendStrategy: null,
+        sentBy: [],
+        userIdentifier: 'davide'
+      })
+    })
+  })
+
+  describe('DELETE /notifications/{id}', () => {
+    test('it should delete a notification', async () => {
+      const created = await server.notificationsService.add({
+        notify: { content: 'Some notification content for Davide' },
+        sendStrategy: 'default',
+        userIdentifier: 'davide'
+      })
+
+      const response = await server.inject({
+        method: 'DELETE',
+        url: `/notifications/${created.id}`
+      })
+
+      expect(response.statusCode).to.equal(200)
+      const result = JSON.parse(response.payload)
+
+      expect(result).to.equal({ success: true })
+    })
+  })
+
+  describe('PUT /notifications/{id}/read', () => {
+    test('it should set a notification to read', async () => {
+      const created = await server.notificationsService.add({
+        notify: { content: 'Some notification content for Davide' },
+        sendStrategy: 'default',
+        userIdentifier: 'davide'
+      })
+
+      const response = await server.inject({
+        method: 'PUT',
+        url: `/notifications/${created.id}/read`
+      })
+
+      expect(response.statusCode).to.equal(200)
+      const result = JSON.parse(response.payload)
+      expect(result.readAt).not.be.null()
+    })
+  })
+
+  describe('PUT /notifications/{id}/unread', () => {
+    test('it should set a notification to unread', async () => {
+      const created = await server.notificationsService.add({
+        notify: { content: 'Some notification content for Davide' },
+        sendStrategy: 'default',
+        userIdentifier: 'davide'
+      })
+
+      await server.inject({
+        method: 'PUT',
+        url: `/notifications/${created.id}/read`
+      })
+
+      const response = await server.inject({
+        method: 'PUT',
+        url: `/notifications/${created.id}/unread`
+      })
+
+      expect(response.statusCode).to.equal(200)
+      const result = JSON.parse(response.payload)
+      expect(result.readAt).to.be.null()
+    })
+  })
+})

--- a/packages/notificami-backend-hapi-16-plugin/test/server.test.js
+++ b/packages/notificami-backend-hapi-16-plugin/test/server.test.js
@@ -22,7 +22,7 @@ describe('Notifications REST API', () => {
   })
 
   after(async () => {
-    return server.stop()
+    server.stop()
   })
 
   describe('GET /users/{userIdentifier}/notifications', () => {

--- a/packages/notificami-backend-hapi-16-plugin/test/test-server.js
+++ b/packages/notificami-backend-hapi-16-plugin/test/test-server.js
@@ -1,14 +1,31 @@
 'use strict'
+const hapi = require('hapi')
+const plugin = require('../lib')
 
 module.exports = async function buildServer(config = {}, options = {}) {
   // If forked as child, send output message via ipc to parent, otherwise output to console
   const logMessage = process.send ? process.send : console.log // eslint-disable-line no-console
 
   try {
-    const server = require('hapi').Server({
+    const server = new hapi.Server()
+    server.connection({
       host: config.host || '127.0.0.1',
       port: config.port || 8080
     })
+
+    server.on('response', function(request) {
+      global.console.log(
+        request.info.remoteAddress +
+          ': ' +
+          request.method.toUpperCase() +
+          ' ' +
+          request.url.path +
+          ' --> ' +
+          request.response.statusCode
+      )
+    })
+
+    server.on('log', ({ tags, data }) => global.console.log([].concat(tags).join('|'), '>', ...[].concat(data)))
 
     if (!config.pluginOptions) {
       config.pluginOptions = {
@@ -20,19 +37,20 @@ module.exports = async function buildServer(config = {}, options = {}) {
         }
       }
     }
-    await server.register({
-      plugin: require('../lib/index'),
-      options: Object.assign({}, config.pluginOptions, {
-        strategies: config.pluginOptions.strategies,
-        channels: config.pluginOptions.channels
-      })
-    })
 
+    await server.register([
+      {
+        register: plugin,
+        options: Object.assign({}, config.pluginOptions, {
+          strategies: config.pluginOptions.strategies,
+          channels: config.pluginOptions.channels
+        })
+      }
+    ])
     server.notificationsService.register('test', 'test-service', options.mockTestService || (() => {}))
-
     return server
   } catch (err) {
-    logMessage(`Failed to build server: ${err.message}`)
+    logMessage(`Failed to build server: ${err.message}\n${err.stack}`)
     process.exit(1)
   }
 }

--- a/packages/notificami-backend-hapi-16-plugin/test/test-server.js
+++ b/packages/notificami-backend-hapi-16-plugin/test/test-server.js
@@ -1,0 +1,38 @@
+'use strict'
+
+module.exports = async function buildServer(config = {}, options = {}) {
+  // If forked as child, send output message via ipc to parent, otherwise output to console
+  const logMessage = process.send ? process.send : console.log // eslint-disable-line no-console
+
+  try {
+    const server = require('hapi').Server({
+      host: config.host || '127.0.0.1',
+      port: config.port || 8080
+    })
+
+    if (!config.pluginOptions) {
+      config.pluginOptions = {
+        strategies: {
+          default: {
+            name: 'default-to-sockets',
+            channels: ['test']
+          }
+        }
+      }
+    }
+    await server.register({
+      plugin: require('../lib/index'),
+      options: Object.assign({}, config.pluginOptions, {
+        strategies: config.pluginOptions.strategies,
+        channels: config.pluginOptions.channels
+      })
+    })
+
+    server.notificationsService.register('test', 'test-service', options.mockTestService || (() => {}))
+
+    return server
+  } catch (err) {
+    logMessage(`Failed to build server: ${err.message}`)
+    process.exit(1)
+  }
+}

--- a/packages/notificami-backend-hapi-16-plugin/test/websocket-subscriptions.test.js
+++ b/packages/notificami-backend-hapi-16-plugin/test/websocket-subscriptions.test.js
@@ -1,0 +1,119 @@
+'use strict'
+
+const Nes = require('nes')
+const { expect } = require('code')
+const sinon = require('sinon')
+const Lab = require('lab')
+module.exports.lab = Lab.script()
+const { describe, it: test, before, after, beforeEach } = module.exports.lab
+
+const { resetDb } = require('@nearform/notificami-backend-core/test/utils')
+const buildServer = require('./test-server')
+
+const delay = (ms = 10) => new Promise(resolve => setTimeout(resolve, ms))
+
+describe('Notification Websocket - routes', () => {
+  let server = null
+  let client = null
+  let mockTestService
+
+  before(async () => {
+    mockTestService = sinon.stub()
+    server = await buildServer(
+      {
+        host: '127.0.0.1',
+        port: 8281,
+        pluginOptions: {
+          channels: {
+            socket: {
+              plugin: '@nearform/notificami-channel-websocket-nes'
+            }
+          },
+          plugins: [{ plugin: '@nearform/notificami-backend-local-queue' }],
+          strategies: {
+            default: {
+              name: 'default-to-sockets',
+              channels: ['socket', 'test']
+            }
+          }
+        }
+      },
+      { mockTestService }
+    )
+
+    await server.start()
+  })
+
+  beforeEach(async () => {
+    mockTestService.reset()
+    await resetDb()
+  })
+
+  after(async () => {
+    return server.stop()
+  })
+
+  describe('Websocket', () => {
+    test('it should be pushed to resource subscribers if the user is connected', async flags => {
+      client = new Nes.Client('ws://127.0.0.1:8281')
+      await client.connect()
+
+      await server.notificationsService.add({
+        notify: { user: 'davide', content: 'Some initial notification' },
+        sendStrategy: 'default',
+        userIdentifier: 'davide'
+      })
+
+      let hasInit = false
+      let hasNew = false
+      await new Promise((resolve, reject) => {
+        async function handler({ payload, type }, flags) {
+          if (type === 'init') {
+            hasInit = true
+            expect(payload.hasMore).to.be.false()
+            expect(payload.items[payload.items.length - 1].notify).to.be.equal({
+              content: 'Some initial notification',
+              user: 'davide'
+            })
+          } else {
+            hasNew = true
+            expect(payload.notify).to.equal({ user: 'davide', content: 'Some notification content' })
+          }
+          if (hasNew && hasInit) {
+            client.disconnect().then(resolve)
+          }
+        }
+
+        return client.subscribe(`/users/davide`, handler).then(async () => {
+          const notification = {
+            notify: { user: 'davide', content: 'Some notification content' },
+            sendStrategy: 'default',
+            userIdentifier: 'davide'
+          }
+          const addedNotification = await server.notificationsService.add(notification)
+
+          await delay(1000)
+          server.notificationsService.send(addedNotification)
+        })
+      })
+    })
+
+    test('it should use another channel if the user is not connected', async flags => {
+      client = new Nes.Client('ws://127.0.0.1:8281')
+      await client.connect()
+
+      mockTestService.returns(Promise.resolve())
+
+      const notification = {
+        notify: { user: 'davide', content: 'Some notification content' },
+        sendStrategy: 'default',
+        userIdentifier: 'davide'
+      }
+      const addedNotification = await server.notificationsService.add(notification)
+      server.notificationsService.notifmeSdk.logger.mute()
+      await server.notificationsService.send(addedNotification)
+
+      expect(mockTestService.called).to.be.true()
+    })
+  })
+})

--- a/packages/notificami-backend-hapi-plugin/lib/index.js
+++ b/packages/notificami-backend-hapi-plugin/lib/index.js
@@ -19,6 +19,7 @@ const notificationsHapiPlugin = {
     }
 
     if (options.storage && options.storage.plugin) {
+      server.log(name, ['use storage plugin', options.storage])
       try {
         await server.register({ plugin: require(options.storage.plugin), options: options.storage.options || {} })
       } catch (e) {
@@ -40,6 +41,7 @@ const notificationsHapiPlugin = {
     server.decorate('request', 'notificationsService', notificationsService)
 
     if (options.channels) {
+      server.log(name, ['use channels', options.channels])
       const channels = Object.keys(options.channels)
       for (let index = 0; index < channels.length; index++) {
         const value = options.channels[channels[index]]
@@ -48,7 +50,7 @@ const notificationsHapiPlugin = {
           try {
             await server.register({ plugin: require(value.plugin), options: value.options || {} })
           } catch (e) {
-            server.log(['error', 'initialize-channel', value.plugin], e)
+            server.log(['error', name, 'initialize-channel', value.plugin], e)
           }
         } else {
           const channel = channels[index]
@@ -61,12 +63,13 @@ const notificationsHapiPlugin = {
     }
 
     if (options.plugins) {
+      server.log(name, ['use plugins', options.plugins])
       for (let index = 0; index < options.plugins.length; index++) {
         const value = options.plugins[index]
         try {
           await server.register({ plugin: require(value.plugin), options: value.options || {} })
         } catch (e) {
-          server.log(['error', 'initialize-plugin', value.plugin], e)
+          server.log(['error', name, 'initialize-plugin', value.plugin], e)
         }
       }
     }

--- a/packages/notificami-backend-hapi-plugin/lib/index.js
+++ b/packages/notificami-backend-hapi-plugin/lib/index.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const Joi = require('joi')
+const { name, version } = require('../package.json')
 const { buildNotificationsService, buildPool, config, PostgresStorage } = require('@nearform/notificami-backend-core')
 
 const schema = Joi.object({
@@ -9,8 +10,8 @@ const schema = Joi.object({
 })
 
 const notificationsHapiPlugin = {
-  name: '@nearform/notificami-hapi-plugin',
-  version: '1.0.0',
+  name,
+  version,
   register: async function(server, options = {}) {
     const result = Joi.validate(options, schema, { allowUnknown: true })
     if (result.error) {

--- a/packages/notificami-backend-hapi-plugin/test/server-register.test.js
+++ b/packages/notificami-backend-hapi-plugin/test/server-register.test.js
@@ -17,7 +17,7 @@ describe('Notifications REST API Registration', () => {
       loggerStub = sinon.spy()
       server = require('hapi').Server({
         host: '127.0.0.1',
-        port: 8080
+        port: 0
       })
       server.events.on('log', loggerStub)
     } catch (err) {
@@ -51,6 +51,6 @@ describe('Notifications REST API Registration', () => {
         }
       }
     })
-    expect(loggerStub.getCall(0).args[0].tags).to.be.equal(['error', 'initialize-storage', 'someplugin'])
+    expect(loggerStub.getCall(1).args[0].tags).to.be.equal(['error', 'initialize-storage', 'someplugin'])
   })
 })

--- a/packages/notificami-backend-hapi-plugin/test/test-server.js
+++ b/packages/notificami-backend-hapi-plugin/test/test-server.js
@@ -10,6 +10,20 @@ module.exports = async function buildServer(config = {}, options = {}) {
       port: config.port || 8080
     })
 
+    server.events.on('response', function(request) {
+      global.console.log(
+        request.info.remoteAddress +
+          ': ' +
+          request.method.toUpperCase() +
+          ' ' +
+          request.url.path +
+          ' --> ' +
+          request.response.statusCode
+      )
+    })
+
+    server.events.on('log', ({ tags, data }) => global.console.log([].concat(tags).join('|'), '>', ...[].concat(data)))
+
     if (!config.pluginOptions) {
       config.pluginOptions = {
         strategies: {

--- a/packages/notificami-backend-hapi-plugin/test/websocket-subscriptions.test.js
+++ b/packages/notificami-backend-hapi-plugin/test/websocket-subscriptions.test.js
@@ -15,6 +15,7 @@ const delay = (ms = 10) => new Promise(resolve => setTimeout(resolve, ms))
 describe('Notification Websocket - routes', () => {
   let server = null
   let client = null
+  let port = null
   let mockTestService
 
   before(async () => {
@@ -22,11 +23,12 @@ describe('Notification Websocket - routes', () => {
     server = await buildServer(
       {
         host: '127.0.0.1',
-        port: 8281,
+        port: 0,
         pluginOptions: {
           channels: {
             socket: {
-              plugin: '@nearform/notificami-channel-websocket-nes'
+              plugin: '@nearform/notificami-channel-websocket-nes',
+              options: { heartbeat: false }
             }
           },
           plugins: [{ plugin: '@nearform/notificami-backend-local-queue' }],
@@ -42,6 +44,8 @@ describe('Notification Websocket - routes', () => {
     )
 
     await server.start()
+    port = server.info.port
+    global.console.log('WS test port :', port)
   })
 
   beforeEach(async () => {
@@ -55,18 +59,21 @@ describe('Notification Websocket - routes', () => {
 
   describe('Websocket', () => {
     test('it should be pushed to resource subscribers if the user is connected', async flags => {
-      client = new Nes.Client('ws://127.0.0.1:8281')
-      await client.connect()
+      return new Promise(async (resolve, reject) => {
+        client = new Nes.Client(`ws://127.0.0.1:${port}`)
+        await client.connect()
 
-      await server.notificationsService.add({
-        notify: { user: 'davide', content: 'Some initial notification' },
-        sendStrategy: 'default',
-        userIdentifier: 'davide'
-      })
+        await delay(1000)
+        await server.notificationsService.add({
+          notify: { user: 'davide', content: 'Some initial notification' },
+          sendStrategy: 'default',
+          userIdentifier: 'davide'
+        })
 
-      let hasInit = false
-      let hasNew = false
-      await new Promise((resolve, reject) => {
+        global.console.warn('⚠️ This test should display an error "Error: User not subscribed"')
+
+        let hasInit = false
+        let hasNew = false
         async function handler({ payload, type }, flags) {
           if (type === 'init') {
             hasInit = true
@@ -84,22 +91,21 @@ describe('Notification Websocket - routes', () => {
           }
         }
 
-        return client.subscribe(`/users/davide`, handler).then(async () => {
-          const notification = {
-            notify: { user: 'davide', content: 'Some notification content' },
-            sendStrategy: 'default',
-            userIdentifier: 'davide'
-          }
-          const addedNotification = await server.notificationsService.add(notification)
+        await client.subscribe(`/users/davide`, handler)
 
-          await delay(1000)
-          server.notificationsService.send(addedNotification)
+        const addedNotification = await server.notificationsService.add({
+          notify: { user: 'davide', content: 'Some notification content' },
+          sendStrategy: 'default',
+          userIdentifier: 'davide'
         })
+
+        await delay(1000)
+        return server.notificationsService.send(addedNotification)
       })
     })
 
     test('it should use another channel if the user is not connected', async flags => {
-      client = new Nes.Client('ws://127.0.0.1:8281')
+      client = new Nes.Client(`ws://127.0.0.1:${port}`)
       await client.connect()
 
       mockTestService.returns(Promise.resolve())

--- a/packages/notificami-backend-local-queue/src/index.js
+++ b/packages/notificami-backend-local-queue/src/index.js
@@ -1,23 +1,36 @@
 'use strict'
 
 const { LocalQueue } = require('./local-queue')
+const pkg = require('../package.json')
 
-async function register(server, options = {}) {
-  const queue = new LocalQueue()
-  queue.consume('notification-queue', async notification => {
-    try {
-      await server.notificationsService.send(notification, notification.sendStrategy)
-    } catch (e) {
-      server.log(['error', 'notification', 'send'], e)
+const { name, version } = pkg
+
+async function register(server, options = {}, next /* hapi 16.x compat */) {
+  try {
+    const queue = new LocalQueue()
+    queue.consume('notification-queue', async notification => {
+      try {
+        await server.notificationsService.send(notification, notification.sendStrategy)
+      } catch (e) {
+        server.log(['error', pkg.name, 'notification', 'send'], `${e.msg}:\n${e.stack}`)
+      }
+    })
+
+    server.notificationsService.on('add', async notification => {
+      await queue.sendToQueue('notification-queue', notification)
+    })
+
+    if (next && typeof next === 'function') {
+      return next()
     }
-  })
-
-  server.notificationsService.on('add', async notification => {
-    await queue.sendToQueue('notification-queue', notification)
-  })
+  } catch (err) {
+    return next(err)
+  }
 }
 
+register.attributes = { name, version }
+
 module.exports = {
-  pkg: require('../package.json'),
+  pkg,
   register
 }

--- a/packages/notificami-backend-sqs-queue/lib/consumer.js
+++ b/packages/notificami-backend-sqs-queue/lib/consumer.js
@@ -16,7 +16,7 @@ class Consumer {
     this.start(this.queue, (err, message, done) => {
       this.handler(err, message, done).catch(err => {
         this.stopped = true
-        console.error(err)
+        global.console.warn('SQS Consumer - consume handler error:\n', err)
       })
 
       if (!this.stopped) this.consume()

--- a/packages/notificami-backend-sqs-queue/test/build-aws-sqs.js
+++ b/packages/notificami-backend-sqs-queue/test/build-aws-sqs.js
@@ -21,7 +21,7 @@ AWS_MOCK.mock('SQS', 'receiveMessage', async () => ({
     {
       MessageId: '73c94793-0b30-426b-87cc-1319605b1d5f',
       ReceiptHandle:
-        'AQEB7zu3d1iWHrbR/7kMN1yU48XWcJtT0lrSBYrOB2BSY/37dLm9uNY5HvgK3dFCxNJbdSL+ZoNZZsIHeT6Bnq5yFabCJFyGMSJSSHmIE3SB9apEiZ47tBaHS35iZXk+X38m8TEXRKrAjVe2rgAPyJbUZUlSpTiPRtHjR6vQa8Sx97OSFJ+smS5YTdHq41fovlohakFjtlO5nJ6a39bLgPYujCup1G+jZuS8xzs0vUBC5joPzzRyqLjbeN1vvN81iR4OnsM0b8Mi3r/s2ZERXKd1m63dF8ph67h9nT+JQGazJ10=',
+        'AQEB7zu3d1iWHrbR/7kMN1yU48XWcJtT0lrSBYrOB2BSY/37dLm9uNY5HvgK3dFCxNJbdSL+ZoNZZsIHeT6Bnq5yFabCJFyGMSJSSHmIE3SB9apEiZ47tBaHS35iZXk+X38m8TEXRKrAjVe2rgAPyJbUZUlSpTiPRtHjR6vQa8Sx97OSFJ+smS5YTdHq41fovlohakFjtlO5nJ6a39bLgPYujCup1G+jZuS8xzs0vUBC5joPzzRyqLjbeN1vvN81iR4OnsM0b8Mi3r/s2ZERXKd1m63dF8ph67h9nT+JQGazJ10=', // eslint-disable-line
       MD5OfBody: 'f32100ce44f559f2854aaf59a4c5f887',
       Body: '...',
       Attributes: { SentTimestamp: '1531208774623' }

--- a/packages/notificami-backend-sqs-queue/test/producer.test.js
+++ b/packages/notificami-backend-sqs-queue/test/producer.test.js
@@ -8,7 +8,9 @@ const Lab = require('lab')
 module.exports.lab = Lab.script()
 const { describe, it: test, after } = module.exports.lab
 
+/* eslint max-len: ["error", { "ignoreComments": true }] */
 /*
+
 Send request response:
 {
   ResponseMetadata: {

--- a/packages/notificami-channel-websocket-nes-6-hapi-16/LICENSE.md
+++ b/packages/notificami-channel-websocket-nes-6-hapi-16/LICENSE.md
@@ -1,0 +1,13 @@
+Copyright (c) 2018 nearForm
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/packages/notificami-channel-websocket-nes-6-hapi-16/README.md
+++ b/packages/notificami-channel-websocket-nes-6-hapi-16/README.md
@@ -1,0 +1,65 @@
+# @nearform/notificami-channel-websocket-nes
+
+This plugin will add a websocket channel to the notification platform.
+
+## Install
+
+```
+npm install @nearform/notificami-channel-websocket-nes
+```
+
+## Configuration
+To use the 'notificami-channel-websocket-nes' as a channel add it in the `channels` property
+
+```
+channels: {
+  socket: {
+    plugin: '@nearform/notificami-channel-websocket-nes'
+  }
+}
+```
+
+and use the name defined in the `channels` (`socket` in the example above) in the strategies definition:
+
+```
+strategies: {
+  default: {
+    name: 'default-to-sockets',
+    channels: ['socket']
+  }
+}
+```
+
+## Connect the client
+
+In the client connect to the service using the components provided by [@nearform/notificami-react-components](https://github.com/nearform/notificami/tree/master/packages/notificami-react-components)
+
+
+```
+import { WebsocketService, buildWebsocketClient, NotificamiProvider, NotificamiWidget } from '@nearform/notificami-react-component'
+
+const client = buildWebsocketClient('ws://127.0.0.1:8482')
+client.connect()
+
+class SamplePage extends React.Component {
+  render() {
+    return (
+      <NotificamiProvider userIdentifier='davide' service={WebsocketService(client)}>
+        <div id='toolbar'>
+          <NotificamiWidget />
+        </div>
+      </NotificamiProvider>
+    )
+  }
+}
+```
+
+
+## License
+
+Copyright nearForm Ltd 2018. Licensed under [Apache 2.0 license][license].
+
+[license]: ./LICENSE.md
+
+## Configuration
+

--- a/packages/notificami-channel-websocket-nes-6-hapi-16/README.md
+++ b/packages/notificami-channel-websocket-nes-6-hapi-16/README.md
@@ -1,11 +1,11 @@
-# @nearform/notificami-channel-websocket-nes
+# @nearform/notificami-channel-websocket-nes-6-hapi-16
 
 This plugin will add a websocket channel to the notification platform.
 
 ## Install
 
 ```
-npm install @nearform/notificami-channel-websocket-nes
+npm install @nearform/notificami-channel-websocket-nes-6-hapi-16
 ```
 
 ## Configuration
@@ -14,7 +14,7 @@ To use the 'notificami-channel-websocket-nes' as a channel add it in the `channe
 ```
 channels: {
   socket: {
-    plugin: '@nearform/notificami-channel-websocket-nes'
+    plugin: '@nearform/notificami-channel-websocket-nes-6-hapi-16'
   }
 }
 ```

--- a/packages/notificami-channel-websocket-nes-6-hapi-16/lib/index.js
+++ b/packages/notificami-channel-websocket-nes-6-hapi-16/lib/index.js
@@ -1,0 +1,42 @@
+'use strict'
+
+const Nes = require('nes')
+const { notifyUser } = require('./subscriptions')
+
+exports.plugin = {
+  pkg: require('../package.json'),
+  register: async function(server, options) {
+    await server.register([
+      {
+        plugin: Nes,
+        options
+      }
+    ])
+
+    server.method('notificationsChannelWebsocketNesNotifyUser', notifyUser.bind(server))
+    server.subscription('/users/{user*}', {
+      onSubscribe: async (socket, path, params) => {
+        setTimeout(async () => {
+          const { user } = params
+          const results = await server.notificationsService.getByUserIdentifier(user)
+          if (results.hasMore === undefined) {
+            results.hasMore = false
+            if (results.items.length > 0) {
+              results.hasMore = await server.notificationsService.hasMoreByUserIdentifier(
+                user,
+                results.items[results.items.length - 1].id
+              )
+            }
+          }
+          await server.publish(`/users/${params.user}`, {
+            type: 'init',
+            payload: { items: results.items, hasMore: results.hasMore }
+          })
+        })
+      }
+    })
+    server.notificationsService.register('socket', 'websocket-nes', async notification => {
+      return server.methods.notificationsChannelWebsocketNesNotifyUser(notification)
+    })
+  }
+}

--- a/packages/notificami-channel-websocket-nes-6-hapi-16/lib/subscriptions.js
+++ b/packages/notificami-channel-websocket-nes-6-hapi-16/lib/subscriptions.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const { promisify } = require('util')
+
 async function notifyUser(notification) {
   const server = this
 
@@ -27,7 +29,10 @@ async function notifyUser(notification) {
   }
 
   // TODO Find a way to check if the message is delivered, an ACK message from the client can be a solution
-  await server.publish(`/users/${notification.userIdentifier}`, { type: 'new', payload: notifyToSend })
+  await promisify(server.publish.bind(server.root))(`/users/${notification.userIdentifier}`, {
+    type: 'new',
+    payload: notifyToSend
+  })
 }
 
 module.exports = {

--- a/packages/notificami-channel-websocket-nes-6-hapi-16/lib/subscriptions.js
+++ b/packages/notificami-channel-websocket-nes-6-hapi-16/lib/subscriptions.js
@@ -1,0 +1,35 @@
+'use strict'
+
+async function notifyUser(notification) {
+  const server = this
+
+  const notifyToSend = {
+    id: notification.id,
+    notify: notification.notify,
+    createdAt: notification.createdAt
+  }
+
+  let isUserSubscribed = false
+  server.eachSocket(
+    socket => {
+      if (!isUserSubscribed) {
+        isUserSubscribed = !!socket._subscriptions[`/users/${notification.userIdentifier}`]
+      }
+    }
+    // @see https://github.com/hapijs/nes/issues/248
+    // ,
+    // { subscription: `/users/${notification.userIdentifier}` }
+  )
+
+  // This is needed beacuse notif.me sdk requires a rejected promise to mark a provider as unsuccessful.
+  if (!isUserSubscribed) {
+    throw new Error('User not subscribed')
+  }
+
+  // TODO Find a way to check if the message is delivered, an ACK message from the client can be a solution
+  await server.publish(`/users/${notification.userIdentifier}`, { type: 'new', payload: notifyToSend })
+}
+
+module.exports = {
+  notifyUser
+}

--- a/packages/notificami-channel-websocket-nes-6-hapi-16/package.json
+++ b/packages/notificami-channel-websocket-nes-6-hapi-16/package.json
@@ -1,8 +1,8 @@
 {
-  "name": "@nearform/notificami-channel-websocket-nes",
+  "name": "@nearform/notificami-channel-websocket-nes-6-hapi-16",
   "version": "0.0.1",
   "main": "lib/index.js",
-  "description": "notificami-channel-websocket-nes",
+  "description": "notificami-channel-websocket-nes-6-hapi-16",
   "homepage": "https://github.com/nearform/notificami#readme",
   "repository": {
     "type": "git",
@@ -20,6 +20,6 @@
   "author": "nearForm Ltd",
   "license": "Apache-2.0",
   "dependencies": {
-    "nes": "^9.0.0"
+    "nes": "^6.5.2"
   }
 }

--- a/packages/notificami-channel-websocket-nes-6-hapi-16/package.json
+++ b/packages/notificami-channel-websocket-nes-6-hapi-16/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@nearform/notificami-channel-websocket-nes",
+  "version": "0.0.1",
+  "main": "lib/index.js",
+  "description": "notificami-channel-websocket-nes",
+  "homepage": "https://github.com/nearform/notificami#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/nearform/notificami.git"
+  },
+  "bugs": {
+    "url": "https://github.com/nearform/notificami/issues"
+  },
+  "engines": {
+    "node": ">=8.9.0"
+  },
+  "scripts": {
+    "depcheck": "../../node_modules/depcheck/bin/depcheck"
+  },
+  "author": "nearForm Ltd",
+  "license": "Apache-2.0",
+  "dependencies": {
+    "nes": "^9.0.0"
+  }
+}

--- a/packages/notificami-react-components/package.json
+++ b/packages/notificami-react-components/package.json
@@ -48,7 +48,6 @@
     "babel-core": "^7.0.0-bridge.0",
     "enzyme": "^3.3.0",
     "enzyme-adapter-react-16": "^1.1.1",
-    "enzyme-context-patch": "^0.0.8",
     "jest": "^23.0.0",
     "jest-environment-jsdom": "^23.1.0",
     "jest-environment-jsdom-global": "^1.1.0",

--- a/packages/notificami-storage-dynamodb/lib/index.js
+++ b/packages/notificami-storage-dynamodb/lib/index.js
@@ -5,23 +5,31 @@ const DynamoDbStorage = require('./storage')
 
 module.exports.plugin = {
   pkg: require('../package.json'),
-  register: async function(server, options) {
-    AWS.config.credentials = new AWS.Credentials(
-      options.ApplicationUserAccessKey,
-      options.ApplicationUserSecretAccessKey
-    )
+  register: async function(server, options, next /* hapi 16.x compat */) {
+    try {
+      AWS.config.credentials = new AWS.Credentials(
+        options.ApplicationUserAccessKey,
+        options.ApplicationUserSecretAccessKey
+      )
 
-    const awsService = {
-      apiVersion: '2012-08-10',
-      region: options.Region
+      const awsService = {
+        apiVersion: '2012-08-10',
+        region: options.Region
+      }
+
+      if (options.AWSEndpoint) {
+        awsService.endpoint = options.AWSEndpoint
+      }
+
+      const storageService = new DynamoDbStorage(new AWS.DynamoDB(awsService), { TableName: options.TableName })
+
+      server.decorate('server', 'storageService', storageService)
+      return next()
+    } catch (err) {
+      if (next && typeof next === 'function') {
+        return next(err)
+      }
+      throw err
     }
-
-    if (options.AWSEndpoint) {
-      awsService.endpoint = options.AWSEndpoint
-    }
-
-    const storageService = new DynamoDbStorage(new AWS.DynamoDB(awsService), { TableName: options.TableName })
-
-    server.decorate('server', 'storageService', storageService)
   }
 }


### PR DESCRIPTION
Should fix #25 

2 forked plugins for supporting Hapi-16.x ( backend one + webscoket/nes one ), made the other ones compatible with Hapi-16.x by supporting the callback api for registration.

Improved a bit the logs (adding a few ones , plus add the plugin name in the tags)

Made some test servers run on auto-attributed ports as well.

Did a couple test refactorings to use more async/await instead of callback or promises

Sorry for the long PR 

(Gosh this was painful !)